### PR TITLE
Extension/associations

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,5 +1,6 @@
 class Cart < ApplicationRecord
   has_many :line_items, dependent: :destroy
+  has_many :products, through: :line_items
 
   def add_product(product)
     current_item = line_items.find_by(product_id: product.id)

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,7 +1,7 @@
 class Cart < ApplicationRecord
   has_many :line_items, dependent: :destroy
   has_many :products, through: :line_items
-  scope :enabled_products, -> { Product.where enabled: true }
+  scope :enabled_products, -> { Product.joins(:carts).where(enabled: true) }
   
   def add_product(product)
     current_item = line_items.find_by(product_id: product.id)

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,7 +1,7 @@
 class Cart < ApplicationRecord
   has_many :line_items, dependent: :destroy
-  has_many :products, through: :line_items
-
+  has_many :products, -> { where enabled: true }, through: :line_items
+  
   def add_product(product)
     current_item = line_items.find_by(product_id: product.id)
 

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,6 +1,7 @@
 class Cart < ApplicationRecord
   has_many :line_items, dependent: :destroy
-  has_many :products, -> { where enabled: true }, through: :line_items
+  has_many :products, through: :line_items
+  scope :enabled_products, -> { Product.where enabled: true }
   
   def add_product(product)
     current_item = line_items.find_by(product_id: product.id)

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -1,7 +1,7 @@
 class LineItem < ApplicationRecord
   belongs_to :order, optional: true
   belongs_to :product
-  belongs_to :cart, optional: true
+  belongs_to :cart, optional: true, counter_cache: true
 
   validates :product, uniqueness: { scope: :cart, message: "One product can be added only once in the cart" }, 
     if: -> { cart.present? }

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,7 +2,7 @@ class Product < ApplicationRecord
   PERMALINK_REGEX = /[[:alnum:]]+/
   validates_with ImageUrlValidator, attributes: [:image_url], if: ->{ image_url.present? }
 
-  has_many :line_items
+  has_many :line_items, dependent: :restrict_with_error
   has_many :orders, through: :line_items
   before_destroy :ensure_not_referenced_by_any_line_item
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -4,6 +4,7 @@ class Product < ApplicationRecord
 
   has_many :line_items, dependent: :restrict_with_error
   has_many :orders, through: :line_items
+  has_many :carts, through: :line_items
   before_destroy :ensure_not_referenced_by_any_line_item
 
   after_initialize do |prod| 


### PR DESCRIPTION
1. We have before_destroy :ensure_not_referenced_by_line_item in Product. Now lets try a better implementation of this  using association options. So a product should not be destroyed if there is any line_item(s) associated with the product.
2.  Create a association on cart through which we could get all the products associated with the cart.
3. Create a association on product through which we could get all the carts associated with the product.
4. Create a association on cart model through which i could get all enabled products associated with it.
5. Everytime a line_item is added or removed from cart, line_items_count column in cart table should be automatically incremented or decremented.